### PR TITLE
Added ; after AMQ_addStyle call

### DIFF
--- a/amqSongDifficultyCounter.user.js
+++ b/amqSongDifficultyCounter.user.js
@@ -977,7 +977,7 @@ function setup() {
             margin-top: 5px;
             margin-left: 15px;
         }
-    `)
+    `);
 
     AMQ_addScriptData({
         name: "Song Difficulty Counter",


### PR DESCRIPTION
There was a missing ; on line 980, solves: https://github.com/TheJoseph98/AMQ-Scripts/issues/20
It didn't allowed the script to load the Script Information on the Installed UserScripts, also stopped other installed scripts info to appear in the same section.