### PR TITLE
Song List UI: Fixing error: Songs with difficulty Unrated are skipped

### DIFF
--- a/amqSongListUI.user.js
+++ b/amqSongListUI.user.js
@@ -1302,7 +1302,7 @@ function setup() {
 	            type: result.songInfo.type === 3 ? "Insert Song" : (result.songInfo.type === 2 ? "Ending " + result.songInfo.typeNumber : "Opening " + result.songInfo.typeNumber),
 	            urls: result.songInfo.urlMap,
 	            siteIds: result.songInfo.siteIds,
-	            difficulty: result.songInfo.animeDifficulty.toFixed(1),
+	            difficulty: typeof result.songInfo.animeDifficulty === "string" ? "Unrated" : result.songInfo.animeDifficulty.toFixed(1),
 	            animeType: result.songInfo.animeType,
 	            animeScore: result.songInfo.animeScore,
 	            vintage: result.songInfo.vintage,


### PR DESCRIPTION
More or less by pure chance I just noticed that songs with a difficulty listed as `Unrated` are not added to the list. I noticed this when I got only seven songs for an eight song CUE! round. And as can be seen [here](https://pastebin.com/Sp83KPzU), song 7 is missing entirely on that list. The commit in this pull request should fix that error by displaying that difficulty as [Unrated](https://i.imgur.com/YSPapJJ.png), but changing it up to a number (like `0`) shouldn't be a problem either.